### PR TITLE
spack v1.0 support: %foo +bar -> +bar %foo

### DIFF
--- a/repos/ucl/packages/gromacs/package.py
+++ b/repos/ucl/packages/gromacs/package.py
@@ -313,8 +313,8 @@ class Gromacs(CMakePackage, CudaPackage):
     depends_on("sycl", when="+sycl")
     depends_on("lapack")
     depends_on("blas")
-    depends_on("gcc", when="%oneapi ~intel_provided_gcc")
-    depends_on("gcc", when="%intel ~intel_provided_gcc")
+    depends_on("gcc", when="~intel_provided_gcc %oneapi")
+    depends_on("gcc", when="~intel_provided_gcc %intel")
 
     depends_on("hwloc@1.0:1", when="+hwloc@2016:2018")
     depends_on("hwloc", when="+hwloc@2019:")


### PR DESCRIPTION
Spack v1.0 will parse `pkg %gcc +foo` as "pkg with direct dependency gcc
with variant foo enabled" instead of "pkg with variant foo enabled and compiler
gcc". Reorder as `pkg +foo %gcc` to be compatible with Spack v0.x and
v1.0.
