### PR TITLE
MJG: Removed the strict version requirement for hdf5 in all of the template yaml files

### DIFF
--- a/spacksites/spack-env-templates/slurm/2025-09_youngmichael/avx2.yaml
+++ b/spacksites/spack-env-templates/slurm/2025-09_youngmichael/avx2.yaml
@@ -26,8 +26,8 @@ spack:
       - gromacs@2024.3 -double
       - gromacs@2023.5 -double +plumed
       - gsl@2.8
-      - hdf5@1.14.3 +cxx +fortran -mpi +hl
-      - hdf5@1.14.3 +fortran +mpi +hl
+      - hdf5 +cxx +fortran -mpi +hl
+      - hdf5 +fortran +mpi +hl
       - htslib@1.17
       - lammps@20240829.1 +mpi +python +amoeba +asphere +bocs +body +bpm +brownian +cg-dna +cg-spica +class2 +colloid +colvars +compress +coreshell +dielectric +diffraction +dipole +dpd-basic +dpd-meso +dpd-react +dpd-smooth +drude +eff +electrode +extra-compute +extra-dump +extra-fix +extra-molecule +extra-pair +fep +granular +interlayer +kspace +lepton +machdyn +manybody +mc +meam +mesont +misc +ml-iap +ml-pod +ml-snap +ml-uf3 +mofff +molecule +openmp +opt +orient +peri +phonon +plugin +poems +qeq +reaction +reaxff +replica +rigid +rheo +shock +sph +spin +srd +tally +uef +voronoi +yaff
       - libxc@6.2.2

--- a/spacksites/spack-env-templates/slurm/2025-09_youngmichael/avx2_intel.yaml
+++ b/spacksites/spack-env-templates/slurm/2025-09_youngmichael/avx2_intel.yaml
@@ -16,7 +16,7 @@ spack:
     - - vasp@6.5.1 +hdf5 ^intel-oneapi-mpi
       - vasp@6.4.3 +hdf5 ^intel-oneapi-mpi
       - vasp@=5.4.4 +scalapack ^intel-oneapi-mpi
-      - hdf5@1.14.3 +fortran +mpi +hl
+      - hdf5 +fortran +mpi +hl
     - - '%oneapi@2024.2.1'
 
   include_concrete:

--- a/spacksites/spack-env-templates/slurm/2025-09_youngmichael/avx512.yaml
+++ b/spacksites/spack-env-templates/slurm/2025-09_youngmichael/avx512.yaml
@@ -18,8 +18,8 @@ spack:
       - gromacs@2024.3 -double
       - gromacs@2023.5 -double +plumed
       - gsl@2.8
-      - hdf5@1.14.3 +cxx +fortran -mpi +hl
-      - hdf5@1.14.3 +fortran +mpi +hl
+      - hdf5 +cxx +fortran -mpi +hl
+      - hdf5 +fortran +mpi +hl
       - htslib@1.17
       - lammps@20240829.1 +mpi +python +amoeba +asphere +bocs +body +bpm +brownian +cg-dna +cg-spica +class2 +colloid +colvars +compress +coreshell +dielectric +diffraction +dipole +dpd-basic +dpd-meso +dpd-react +dpd-smooth +drude +eff +electrode +extra-compute +extra-dump +extra-fix +extra-molecule +extra-pair +fep +granular +interlayer +kspace +lepton +machdyn +manybody +mc +meam +mesont +misc +ml-iap +ml-pod +ml-snap +ml-uf3 +mofff +molecule +openmp +opt +orient +peri +phonon +plugin +poems +qeq +reaction +reaxff +replica +rigid +rheo +shock +sph +spin +srd +tally +uef +voronoi +yaff
       - libxc@6.2.2

--- a/spacksites/spack-env-templates/slurm/2025-09_youngmichael/avx512_intel.yaml
+++ b/spacksites/spack-env-templates/slurm/2025-09_youngmichael/avx512_intel.yaml
@@ -11,7 +11,7 @@ spack:
     - - vasp@6.5.1 +hdf5 ^intel-oneapi-mpi
       - vasp@6.4.3 +hdf5 ^intel-oneapi-mpi
       - vasp@=5.4.4 +scalapack ^intel-oneapi-mpi
-      - hdf5@1.14.3 +fortran +mpi +hl
+      - hdf5 +fortran +mpi +hl
     - - 'target=x86_64_v4 %oneapi@2024.2.1'
 
   include_concrete:


### PR DESCRIPTION
This is for 2025-09_youngmichael